### PR TITLE
Add brochure download command

### DIFF
--- a/cart/views.py
+++ b/cart/views.py
@@ -27,9 +27,9 @@ def add_to_cart(request):
     product_id = data.get('product_id')
     quantity = data.get('quantity', 1)
 
-<<<<<<< HEAD
-    if not product_id:
-=======
+    if product_id is None:
+        return JsonResponse({'error': 'Missing required fields'}, status=400)
+
     try:
         quantity = int(quantity)
     except (TypeError, ValueError):
@@ -37,10 +37,6 @@ def add_to_cart(request):
 
     if quantity <= 0:
         return JsonResponse({'error': 'Invalid quantity'}, status=400)
-
-    if not user_id or not product_id:
->>>>>>> main
-        return JsonResponse({'error': 'Missing required fields'}, status=400)
 
     try:
         product = Product.objects.get(id=product_id)
@@ -48,12 +44,6 @@ def add_to_cart(request):
         return JsonResponse({'error': 'Product not found'}, status=404)
     user = request.user
     cart = get_user_cart(user)
-    try:
-        quantity = int(quantity)
-    except (TypeError, ValueError):
-        return JsonResponse({'error': 'Invalid quantity'}, status=400)
-    if quantity <= 0:
-        return JsonResponse({'error': 'Invalid quantity'}, status=400)
 
     item, created = CartItem.objects.get_or_create(
         cart=cart,
@@ -80,12 +70,10 @@ def update_cart_item(request):
     product_id = data.get('product_id')
     quantity = data.get('quantity')
 
-    if not product_id or quantity is None:
+    if product_id is None or quantity is None:
         return JsonResponse({'error': 'Missing required fields'}, status=400)
 
     try:
-<<<<<<< HEAD
-=======
         quantity = int(quantity)
     except (TypeError, ValueError):
         return JsonResponse({'error': 'Invalid quantity'}, status=400)
@@ -94,8 +82,6 @@ def update_cart_item(request):
         return JsonResponse({'error': 'Invalid quantity'}, status=400)
 
     try:
-        user = User.objects.get(id=user_id)
->>>>>>> main
         product = Product.objects.get(id=product_id)
     except Product.DoesNotExist:
         return JsonResponse({'error': 'Product not found'}, status=404)
@@ -106,17 +92,6 @@ def update_cart_item(request):
         item = CartItem.objects.get(cart=cart, product=product)
     except CartItem.DoesNotExist:
         return JsonResponse({'error': 'Item not in cart'}, status=404)
-
-<<<<<<< HEAD
-    try:
-        quantity = int(quantity)
-    except (TypeError, ValueError):
-        return JsonResponse({'error': 'Invalid quantity'}, status=400)
-    if quantity <= 0:
-        return JsonResponse({'error': 'Invalid quantity'}, status=400)
-
-=======
->>>>>>> main
     item.quantity = quantity
     item.save()
 

--- a/products/management/commands/download_brochures.py
+++ b/products/management/commands/download_brochures.py
@@ -1,0 +1,61 @@
+import os
+from django.core.management.base import BaseCommand
+from django.core.files.base import ContentFile
+from django.utils.text import slugify
+from products.models import Product
+import requests
+
+
+BROCHURE_BASE_URL = os.environ.get(
+    "BROCHURE_BASE_URL",
+    "https://example.com/brochures/",
+)
+
+
+class Command(BaseCommand):
+    """Download PDF brochures for products and attach them."""
+
+    help = "Télécharge les fiches techniques PDF pour chaque produit."
+
+    def handle(self, *args, **options):
+        for product in Product.objects.all():
+            if product.pdf_brochure:
+                self.stdout.write(
+                    self.style.NOTICE(
+                        f"ℹ️ Fiche déjà présente pour {product.name}"
+                    )
+                )
+                continue
+
+            identifier = product.barcode or product.default_code
+            if not identifier:
+                identifier = slugify(product.name)
+            pdf_name = f"{identifier}.pdf"
+            url = f"{BROCHURE_BASE_URL.rstrip('/')}/{pdf_name}"
+
+            try:
+                response = requests.get(url, timeout=15)
+                if response.status_code == 200:
+                    product.pdf_brochure.save(
+                        pdf_name, ContentFile(response.content), save=True
+                    )
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f"✅ Fiche ajoutée pour {product.name}"
+                        )
+                    )
+                else:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"⚠️ Fiche manquante pour {product.name}"
+                        )
+                    )
+            except requests.RequestException as exc:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Erreur téléchargement {product.name}: {exc}"
+                    )
+                )
+
+        self.stdout.write(self.style.SUCCESS("🎉 Téléchargement terminé"))
+


### PR DESCRIPTION
## Summary
- fix merge conflicts in cart views and clean up logic
- add `download_brochures` management command to fetch PDF brochures

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_684eb9838f38832ca6285ccfcbcfcf4e