### PR TITLE
Implement product category classifier

### DIFF
--- a/products/tests/test_classify.py
+++ b/products/tests/test_classify.py
@@ -1,0 +1,20 @@
+from django.test import SimpleTestCase
+from products.utils import classify
+
+
+class ClassifyTests(SimpleTestCase):
+    def test_video_analogique(self):
+        self.assertEqual(classify("DS-2AE123"), ["Vidéo analogique", "Caméras PTZ"])
+        self.assertEqual(classify("DS-2CE999"), ["Vidéo analogique", "Caméras fixes"])
+        self.assertEqual(classify("DS-7200"), ["Vidéo analogique", "DVR"])
+
+    def test_video_ip(self):
+        self.assertEqual(classify("ds-2df001"), ["Vidéo IP", "Caméras PTZ"])
+        self.assertEqual(classify("DS-2CD321"), ["Vidéo IP", "Caméras fixes"])
+        self.assertEqual(classify("DS-7632"), ["Vidéo IP", "NVR"])
+        self.assertEqual(classify("DS-3E0101"), ["Vidéo IP", "Switches PoE"])
+        self.assertEqual(classify("DS-A123"), ["Vidéo IP", "Stockage IP SAN/NAS"])
+
+    def test_default(self):
+        self.assertEqual(classify("UNKNOWN"), ["Non classé"])
+        self.assertEqual(classify(""), ["Non classé"])

--- a/products/utils.py
+++ b/products/utils.py
@@ -1,4 +1,5 @@
 import xmlrpc.client
+import re
 from .models import Product
 from django.utils.text import slugify
 
@@ -50,3 +51,79 @@ def fetch_products_from_odoo():
                 'search_tags': f"{product['name']}, {product['default_code']}, {product.get('barcode', '')}"
             }
         )
+
+
+def classify(sku_raw: str):
+    """Return category path for a given SKU or label."""
+    if not sku_raw:
+        return ["Non classé"]
+
+    sku = sku_raw.strip().upper()
+
+    def contains_any(text, keywords):
+        return any(word in text for word in keywords)
+
+    # --- Vidéo analogique ---------------------------------
+    if sku.startswith("DS-2AE"):
+        return ["Vidéo analogique", "Caméras PTZ"]
+    if sku.startswith("DS-2CE"):
+        return ["Vidéo analogique", "Caméras fixes"]
+    if sku.startswith("DS-72") or sku.startswith("DS-71"):
+        return ["Vidéo analogique", "DVR"]
+
+    # --- Vidéo IP -----------------------------------------
+    if sku.startswith("DS-2DF") or sku.startswith("DS-2DE"):
+        return ["Vidéo IP", "Caméras PTZ"]
+    if sku.startswith("DS-2CD"):
+        return ["Vidéo IP", "Caméras fixes"]
+    if re.match(r"^DS-7[6-8]", sku):
+        return ["Vidéo IP", "NVR"]
+    if sku.startswith("DS-3E"):
+        return ["Vidéo IP", "Switches PoE"]
+    if sku.startswith("DS-A"):
+        return ["Vidéo IP", "Stockage IP SAN/NAS"]
+
+    # --- Hybride ------------------------------------------
+    if sku.startswith("DS-90"):
+        return ["Hybride/HCVR", "DVR Hybride"]
+
+    # --- Contrôle d'accès & Interphonie -------------------
+    if sku.startswith("DS-KD"):
+        return ["Contrôle d’accès & Interphonie", "Interphonie vidéo", "Door station"]
+    if sku.startswith("DS-KH"):
+        return ["Contrôle d’accès & Interphonie", "Interphonie vidéo", "Indoor station"]
+    if sku.startswith("DS-K1") or sku.startswith("DS-K2"):
+        return ["Contrôle d’accès & Interphonie", "Contrôleurs & lecteurs"]
+
+    # --- Alarme intrusion ---------------------------------
+    if sku.startswith("DS-PWA") or sku.startswith("DS-PMA"):
+        return ["Alarme intrusion", "Centrales"]
+    if sku.startswith("DS-PD") or sku.startswith("DS-PS") or sku.startswith("DS-PT") or sku.startswith("DS-PDE"):
+        return ["Alarme intrusion", "Détecteurs / contacts / sirènes"]
+    if sku.startswith("DS-PK") or sku.startswith("DS-PR") or sku.startswith("DS-PF"):
+        return ["Alarme intrusion", "Périphériques"]
+
+    # --- Affichage ----------------------------------------
+    if sku.startswith("DS-D5") or sku.startswith("DS-D6"):
+        return ["Affichage & mur d’images", "Moniteurs"]
+    if sku.startswith("DS-C1") or sku.startswith("DS-VD"):
+        return ["Affichage & mur d’images", "Décoders / contrôleurs"]
+
+    # --- Spécialisations diverses -------------------------
+    if sku.startswith("DS-M"):
+        return ["Autres spécialisations", "Mobile / Bodycam"]
+    if sku.startswith("DS-T"):
+        return ["Autres spécialisations", "Traffic / radar"]
+    if sku.startswith("DS-2TD") or sku.startswith("DS-2TE"):
+        return ["Autres spécialisations", "Thermique"]
+
+    # --- Accessoires génériques (mots-clés) ---------------
+    if contains_any(sku, ["BALUN", "BNC", "DC", "BRACKET", "MOUNT", "POE", "RJ45"]):
+        return ["Accessoires généraux", "Câbles & connectique"]
+    if contains_any(sku, ["HDD", "SSD"]):
+        return ["Accessoires généraux", "Disques durs"]
+    if sku.startswith("DS-12") or sku.startswith("DS-127") or sku.startswith("DS-129"):
+        return ["Accessoires généraux", "Supports & boîtiers"]
+
+    # --- Par défaut ---------------------------------------
+    return ["Non classé"]


### PR DESCRIPTION
## Summary
- add `classify` in `products/utils.py` for SKU-based categorisation
- cover classification rules with new tests

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_686a259805c0832e961bf7e2d2ccd197