### PR TITLE
Implement automatic product categorization

### DIFF
--- a/products/classifier.py
+++ b/products/classifier.py
@@ -1,0 +1,77 @@
+import re
+
+
+def classify(sku_raw: str):
+    """Return category path for a given SKU or label."""
+    if not sku_raw:
+        return ["Non classé"]
+
+    sku = sku_raw.strip().upper()
+
+    def contains_any(text, keywords):
+        return any(word in text for word in keywords)
+
+    # --- Vidéo analogique ---------------------------------
+    if sku.startswith("DS-2AE"):
+        return ["Vidéo analogique", "Caméras PTZ"]
+    if sku.startswith("DS-2CE"):
+        return ["Vidéo analogique", "Caméras fixes"]
+    if sku.startswith("DS-72") or sku.startswith("DS-71"):
+        return ["Vidéo analogique", "DVR"]
+
+    # --- Vidéo IP -----------------------------------------
+    if sku.startswith("DS-2DF") or sku.startswith("DS-2DE"):
+        return ["Vidéo IP", "Caméras PTZ"]
+    if sku.startswith("DS-2CD"):
+        return ["Vidéo IP", "Caméras fixes"]
+    if re.match(r"^DS-7[6-8]", sku):
+        return ["Vidéo IP", "NVR"]
+    if sku.startswith("DS-3E"):
+        return ["Vidéo IP", "Switches PoE"]
+    if sku.startswith("DS-A"):
+        return ["Vidéo IP", "Stockage IP SAN/NAS"]
+
+    # --- Hybride ------------------------------------------
+    if sku.startswith("DS-90"):
+        return ["Hybride/HCVR", "DVR Hybride"]
+
+    # --- Contrôle d'accès & Interphonie -------------------
+    if sku.startswith("DS-KD"):
+        return ["Contrôle d’accès & Interphonie", "Interphonie vidéo", "Door station"]
+    if sku.startswith("DS-KH"):
+        return ["Contrôle d’accès & Interphonie", "Interphonie vidéo", "Indoor station"]
+    if sku.startswith("DS-K1") or sku.startswith("DS-K2"):
+        return ["Contrôle d’accès & Interphonie", "Contrôleurs & lecteurs"]
+
+    # --- Alarme intrusion ---------------------------------
+    if sku.startswith("DS-PWA") or sku.startswith("DS-PMA"):
+        return ["Alarme intrusion", "Centrales"]
+    if sku.startswith("DS-PD") or sku.startswith("DS-PS") or sku.startswith("DS-PT") or sku.startswith("DS-PDE"):
+        return ["Alarme intrusion", "Détecteurs / contacts / sirènes"]
+    if sku.startswith("DS-PK") or sku.startswith("DS-PR") or sku.startswith("DS-PF"):
+        return ["Alarme intrusion", "Périphériques"]
+
+    # --- Affichage ----------------------------------------
+    if sku.startswith("DS-D5") or sku.startswith("DS-D6"):
+        return ["Affichage & mur d’images", "Moniteurs"]
+    if sku.startswith("DS-C1") or sku.startswith("DS-VD"):
+        return ["Affichage & mur d’images", "Décoders / contrôleurs"]
+
+    # --- Spécialisations diverses -------------------------
+    if sku.startswith("DS-M"):
+        return ["Autres spécialisations", "Mobile / Bodycam"]
+    if sku.startswith("DS-T"):
+        return ["Autres spécialisations", "Traffic / radar"]
+    if sku.startswith("DS-2TD") or sku.startswith("DS-2TE"):
+        return ["Autres spécialisations", "Thermique"]
+
+    # --- Accessoires génériques (mots-clés) ---------------
+    if contains_any(sku, ["BALUN", "BNC", "DC", "BRACKET", "MOUNT", "POE", "RJ45"]):
+        return ["Accessoires généraux", "Câbles & connectique"]
+    if contains_any(sku, ["HDD", "SSD"]):
+        return ["Accessoires généraux", "Disques durs"]
+    if sku.startswith("DS-12") or sku.startswith("DS-127") or sku.startswith("DS-129"):
+        return ["Accessoires généraux", "Supports & boîtiers"]
+
+    # --- Par défaut ---------------------------------------
+    return ["Non classé"]

--- a/products/management/commands/classify_products.py
+++ b/products/management/commands/classify_products.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+from products.models import Product
+from products.classifier import classify
+
+class Command(BaseCommand):
+    help = "Applique la fonction classify à tous les produits pour renseigner categ_id"
+
+    def handle(self, *args, **options):
+        updated = 0
+        for product in Product.objects.all():
+            sku = product.default_code or product.name
+            category = " / ".join(classify(sku))
+            if product.categ_id != category:
+                product.categ_id = category
+                product.save(update_fields=["categ_id"])
+                updated += 1
+        self.stdout.write(self.style.SUCCESS(f"{updated} produits mis à jour"))

--- a/products/models.py
+++ b/products/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils.text import slugify
+from .classifier import classify
 
 class Product(models.Model):
     odoo_id = models.IntegerField(unique=True, null=True)  # ID Odoo
@@ -56,6 +57,10 @@ class Product(models.Model):
 
     def save(self, *args, **kwargs):
         """ Génération automatique des champs SEO avant sauvegarde """
+
+        # 0️⃣ Mettre à jour automatiquement la catégorie à partir du SKU ou du nom
+        sku_source = self.default_code or self.name
+        self.categ_id = " / ".join(classify(sku_source))
 
         # 1️⃣ Générer le slug basé sur le `barcode` ou `name`
         if not self.slug:

--- a/products/tests/test_classify.py
+++ b/products/tests/test_classify.py
@@ -1,0 +1,20 @@
+from django.test import SimpleTestCase
+from products.classifier import classify
+
+
+class ClassifyTests(SimpleTestCase):
+    def test_video_analogique(self):
+        self.assertEqual(classify("DS-2AE123"), ["Vidéo analogique", "Caméras PTZ"])
+        self.assertEqual(classify("DS-2CE999"), ["Vidéo analogique", "Caméras fixes"])
+        self.assertEqual(classify("DS-7200"), ["Vidéo analogique", "DVR"])
+
+    def test_video_ip(self):
+        self.assertEqual(classify("ds-2df001"), ["Vidéo IP", "Caméras PTZ"])
+        self.assertEqual(classify("DS-2CD321"), ["Vidéo IP", "Caméras fixes"])
+        self.assertEqual(classify("DS-7632"), ["Vidéo IP", "NVR"])
+        self.assertEqual(classify("DS-3E0101"), ["Vidéo IP", "Switches PoE"])
+        self.assertEqual(classify("DS-A123"), ["Vidéo IP", "Stockage IP SAN/NAS"])
+
+    def test_default(self):
+        self.assertEqual(classify("UNKNOWN"), ["Non classé"])
+        self.assertEqual(classify(""), ["Non classé"])

--- a/products/tests/test_classify_command.py
+++ b/products/tests/test_classify_command.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+from django.core.management import call_command
+from products.models import Product
+
+class ClassifyProductsCommandTests(TestCase):
+    def test_command_updates_categories(self):
+        p = Product.objects.create(name='Cam', default_code='DS-2CD1', list_price=1, categ_id='')
+        call_command('classify_products')
+        p.refresh_from_db()
+        self.assertEqual(p.categ_id, 'Vidéo IP / Caméras fixes')

--- a/products/tests/test_product_auto_classification.py
+++ b/products/tests/test_product_auto_classification.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+from products.models import Product
+
+class ProductAutoClassificationTests(TestCase):
+    def test_save_auto_sets_category(self):
+        product = Product.objects.create(
+            name='Camera', default_code='DS-2CD123', list_price=1, categ_id=''
+        )
+        product.refresh_from_db()
+        self.assertEqual(product.categ_id, 'Vid\xe9o IP / Cam\xe9ras fixes')
+

--- a/products/utils.py
+++ b/products/utils.py
@@ -1,6 +1,7 @@
 import xmlrpc.client
 from .models import Product
 from django.utils.text import slugify
+from .classifier import classify
 
 
 ODOO_URL = "https://labr1.odoo.com/xmlrpc/2/object"
@@ -50,3 +51,5 @@ def fetch_products_from_odoo():
                 'search_tags': f"{product['name']}, {product['default_code']}, {product.get('barcode', '')}"
             }
         )
+
+


### PR DESCRIPTION
## Summary
- move SKU classifier to `classifier.py`
- update management command and tests to import from the new module
- auto-classify products whenever they are saved
- add unit test covering automatic classification

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`
- `python manage.py classify_products`

------
https://chatgpt.com/codex/tasks/task_b_686a259805c0832e961bf7e2d2ccd197