### PR TITLE
Add detailed Hikvision category inference

### DIFF
--- a/products/migrations/0007_populate_product_categories.py
+++ b/products/migrations/0007_populate_product_categories.py
@@ -5,7 +5,11 @@ from products.classifier import classify
 def populate_categories(apps, schema_editor):
     Product = apps.get_model('products', 'Product')
     for product in Product.objects.all():
-        categories = classify(product.barcode or product.default_code or product.name)
+        categories = classify(
+            product.default_code or product.barcode or product.name,
+            product.category_main,
+            product.category_sub,
+        )
         product.category_main = categories[0] if len(categories) > 0 else None
         product.category_sub = categories[1] if len(categories) > 1 else None
         product.category_type = categories[2] if len(categories) > 2 else None

--- a/products/models.py
+++ b/products/models.py
@@ -61,8 +61,12 @@ class Product(models.Model):
     def save(self, *args, **kwargs):
         """ Génération automatique des champs SEO avant sauvegarde """
 
-        # Appliquer la classification sur le barcode ou la référence
-        categories = classify(self.barcode or self.default_code or self.name)
+        # Appliquer la classification sur la référence (ou barcode / nom en secours)
+        categories = classify(
+            self.default_code or self.barcode or self.name,
+            self.category_main,
+            self.category_sub,
+        )
         self.category_main = categories[0] if len(categories) > 0 else None
         self.category_sub = categories[1] if len(categories) > 1 else None
         self.category_type = categories[2] if len(categories) > 2 else None

--- a/products/tests/test_classify.py
+++ b/products/tests/test_classify.py
@@ -3,18 +3,33 @@ from products.classifier import classify
 
 
 class ClassifyTests(SimpleTestCase):
-    def test_video_analogique(self):
-        self.assertEqual(classify("DS-2AE123"), ["Vidéo analogique", "Caméras PTZ"])
-        self.assertEqual(classify("DS-2CE999"), ["Vidéo analogique", "Caméras fixes"])
-        self.assertEqual(classify("DS-7200"), ["Vidéo analogique", "DVR"])
+    def test_hikvision_rules(self):
+        self.assertEqual(
+            classify("DS-2CD2043G2-I"),
+            ["Vidéosurveillance IP", "Caméras IP", "Caméra IP fixe"],
+        )
+        self.assertEqual(
+            classify("DS-2DE4425IW-DE"),
+            ["Vidéosurveillance IP", "Caméras PTZ", "PTZ IP"],
+        )
+        self.assertEqual(
+            classify("DS-76XXNI"),
+            ["Enregistreurs", "NVR IP", "NVR"],
+        )
+        self.assertEqual(
+            classify("DS-K2604"),
+            ["Contrôle d'accès", "Contrôleurs & modules", None],
+        )
+        self.assertEqual(
+            classify("BNC-123"),
+            ["Accessoires généraux", "Câbles & connectique", "Connecteurs & fiches"],
+        )
 
-    def test_video_ip(self):
-        self.assertEqual(classify("ds-2df001"), ["Vidéo IP", "Caméras PTZ"])
-        self.assertEqual(classify("DS-2CD321"), ["Vidéo IP", "Caméras fixes"])
-        self.assertEqual(classify("DS-7632"), ["Vidéo IP", "NVR"])
-        self.assertEqual(classify("DS-3E0101"), ["Vidéo IP", "Switches PoE"])
-        self.assertEqual(classify("DS-A123"), ["Vidéo IP", "Stockage IP SAN/NAS"])
+    def test_fallback_to_existing_categories(self):
+        self.assertEqual(
+            classify("UNKNOWN", "Catégorie Odoo", "Sous-catégorie Odoo"),
+            ["Catégorie Odoo", "Sous-catégorie Odoo", None],
+        )
 
-    def test_default(self):
-        self.assertEqual(classify("UNKNOWN"), ["Non classé"])
+    def test_default_when_no_match(self):
         self.assertEqual(classify(""), ["Non classé"])


### PR DESCRIPTION
## Summary
- add Hikvision reference rules and an inference helper that fall back to existing categories
- reuse the new classification when syncing products, saving models, and backfilling data
- update classification tests and enable discovery for the products test package

## Testing
- python manage.py test products.tests.test_classify


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929bf8f4904832eb9df5806eee667ee)